### PR TITLE
private repos, if not yarn warns and not install.

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "private": "true",
   "scripts": {
     "start:dev": "nodemon --watch 'src/**/*.ts' --watch './.env'",
     "start:db": "json-server --port 5000 --watch db.json"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "private": "true",
   "workspaces": {
     "packages": [
       "api",


### PR DESCRIPTION
yarn setup:api won't work because of: warning Workspaces can only be enabled in private projects.

as sugested is working as espected.